### PR TITLE
Save and Load the solver as well.

### DIFF
--- a/character_demo.html
+++ b/character_demo.html
@@ -217,6 +217,17 @@ var saveModel = function() {
     }
   }
   out['model'] = model_out;
+  var solver_out = {};
+  solver_out['decay_rate'] = solver.decay_rate;
+  solver_out['smooth_eps'] = solver.smooth_eps;
+  step_cache_out = {};
+  for(var k in solver.step_cache) {
+    if(solver.step_cache.hasOwnProperty(k)) {
+      step_cache_out[k] = solver.step_cache[k].toJSON();
+    }
+  }
+  solver_out['step_cache'] = step_cache_out;
+  out['solver'] = solver_out;
   out['letterToIndex'] = letterToIndex;
   out['indexToLetter'] = indexToLetter;
   out['vocab'] = vocab;
@@ -235,6 +246,17 @@ var loadModel = function(j) {
       model[k].fromJSON(matjson);
     }
   }
+  solver = new R.Solver(); // have to reinit the solver since model changed
+  solver.decay_rate = j.solver.decay_rate;
+  solver.smooth_eps = j.solver.smooth_eps;
+  solver.step_cache = {};
+  for(var k in j.solver.step_cache){
+      if(j.solver.step_cache.hasOwnProperty(k)){
+          var matjson = j.solver.step_cache[k];
+          solver.step_cache[k] = new R.Mat(1,1);
+          solver.step_cache[k].fromJSON(matjson);
+      }
+  }
   letterToIndex = j['letterToIndex'];
   indexToLetter = j['indexToLetter'];
   vocab = j['vocab'];
@@ -242,7 +264,6 @@ var loadModel = function(j) {
   // reinit these
   ppl_list = [];
   tick_iter = 0;
-  solver = new R.Solver(); // have to reinit the solver since model changed
 }
 
 var forwardIndex = function(G, model, ix, prev) {


### PR DESCRIPTION
Hi !

Somebody noticed a spike in perplexity after loading the model. This spike disappears if we save and load the solver as well.

I tested this change by feeding the same sequence of sentences when executing from start as when starting back from a certain tick  by loading the model (and solver), and the perplexities match exactly, whereas if the solver is not loaded, there is a spike that takes a few ticks to disappear.
